### PR TITLE
Se Modifica a que solo tenga 1 Worker para hacer la ejecución

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: 'POM/tests',
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */


### PR DESCRIPTION
Se modifican configuraciones del .json del Framework para que corran los test con 1 worker, los test se corraran de esta manera de una por una en vez de manera paralela.

Motivo: Al utilizar los test un mismo archivo Excel se genera un problema al marcar como ocupado el archivo excell