### PR TITLE
Bug fix contador en mensaje incorrecto

### DIFF
--- a/POM/pages/testPlan.page.ts
+++ b/POM/pages/testPlan.page.ts
@@ -59,9 +59,9 @@ export class TestPlan extends BasePage {
 
             //CARGA LOS DATOS EN LA VARIABLE DATOS
             for (let i = fila; i <= ultimaFila; i++) {
-                const nombrePrueba: string = worksheet['E' + i]?.w;
+                const nombrePrueba: string = worksheet['H' + i]?.w;
                 const precondiciones: string = worksheet['F' + i]?.w;
-                const script: string = worksheet['H' + i]?.w;
+                const script: string = worksheet['I' + i]?.w;
                 datos.push({ nombrePrueba, precondiciones, script });
             }
 
@@ -69,9 +69,9 @@ export class TestPlan extends BasePage {
             const LlenarCampos = async (dato: Dato) => {
                 const { nombrePrueba, precondiciones, script } = dato;
 
-                await this.testStep.fill(script);
-                await this.testData.fill(nombrePrueba);
-                await this.testResult.fill(precondiciones);
+                await this.testStep.fill(nombrePrueba);
+                await this.testData.fill(precondiciones);
+                await this.testResult.fill(script);
                 await this.addSteps.click();
             };
             //LLAMA LA FUNCION PARA LLENAR LOS DATOS, DESPUES DE LLENAR UNO, DA UN TIEMPO DE ESPERA A QUE SE REGISTRE EL DATO ANTERIOR PARA QUE NO REGISTRE DATOS EN BLANCO
@@ -83,7 +83,7 @@ export class TestPlan extends BasePage {
             console.log("Casos actuales en jira para los registros tipo"+ " " + hoja_excell + ": " + registros_iniciales)
             console.log("Casos para registrar disponibles en la matriz:" + " " + (ultimaFila - fila + 1 ) + '\n')
             const tiempoEspera = 1500;
-            var count = registros_iniciales + 1;
+            var count =  1;
             for (const dato of datos) {
                 console.log(`Cargando dato ${count}...`)
                 await LlenarCampos(dato);
@@ -95,7 +95,7 @@ export class TestPlan extends BasePage {
             }
             const registros_finales = await this.obtenerRegistros();
             console.log("Casos procesados/cargados en jira para el tipo " + hoja_excell + " " +  "son" + " " + (registros_finales-registros_iniciales))
-            console.log("Total de casos registrados en jira para el test case tipo " +" " + hoja_excell + " " + (registros_finales + 1));
+            console.log("Total de casos registrados en jira para el test case tipo " +" " + hoja_excell + " " + (registros_finales));
             console.log(`************************************************************************`);
         } catch (error) {
             console.log('++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++' + error);

--- a/POM/pages/testPlan.page.ts
+++ b/POM/pages/testPlan.page.ts
@@ -139,7 +139,7 @@ export class TestPlan extends BasePage {
         const tiempoEspera = 1000;
         let btnDeleteElement = await frameContent?.$('//div[@title="Delete"]');
         let btnDeleteElementTotal = await frameContent?.$$('//div[@title="Delete"]');
-        let cantidadTotal = btnDeleteElementTotal?.length != null ? btnDeleteElementTotal?.length + 1 : btnDeleteElementTotal?.length;
+        let cantidadTotal = btnDeleteElementTotal?.length != null ? btnDeleteElementTotal?.length /*+ 1*/ : btnDeleteElementTotal?.length;
         let contEliminados = 0;
         let count = 1;
         console.log(`\n************************** ELIMINANDO ${nombrePrueba} *****************************`)

--- a/POM/tests/cargarJira.spec.ts
+++ b/POM/tests/cargarJira.spec.ts
@@ -9,7 +9,6 @@ test.only('funcionalPositivo', async ({page}) => {
     const basePage = new BasePage(page);
     const testPlan = new TestPlan(page) 
     await basePage.iniciarSesison('FUNCIONAL POSITIVO');
-    //await testPlan.eliminarRegistros('FUNCIONAL POSITIVO');
     await testPlan.registrarMatriz('FUNCIONAL POSITIVO', 16);
 })
 
@@ -19,7 +18,6 @@ test('funcionalNegativo', async ({page}) => { //no escribe nada ni no marca erro
     const basePage = new BasePage(page);
     const testPlan = new TestPlan(page) 
     await basePage.iniciarSesison('FUNCIONAL NEGATIVO');
-    //await testPlan.eliminarRegistros('FUNCIONAL NEGATIVO');
     await testPlan.registrarMatriz('FUNCIONAL NEGATIVO', 15);
 })
 
@@ -29,7 +27,6 @@ test('excepcion', async ({page}) => { //no escribe nada ni no marca error
     const basePage = new BasePage(page);
     const testPlan = new TestPlan(page) 
     await basePage.iniciarSesison('EXCEPCIÓN');
-    //await testPlan.eliminarRegistros('EXCEPCIÓN');
     await testPlan.registrarMatriz('EXCEPCIÓN', 15);
 })
 
@@ -39,6 +36,41 @@ test('noAfectacion', async ({page}) => {
     const basePage = new BasePage(page);
     const testPlan = new TestPlan(page) 
     await basePage.iniciarSesison('NO AFECTACIÓN');
-    //await testPlan.eliminarRegistros('NO AFECTACIÓN');
     await testPlan.registrarMatriz('NO AFECTACIÓN', 14);
+})
+
+
+//TEST PARA ELIMINAR REGISTROS EN JIRA
+test('DeletefuncionalPositivo', async ({page}) => {
+    const basePage = new BasePage(page);
+    const testPlan = new TestPlan(page) 
+    await basePage.iniciarSesison('FUNCIONAL POSITIVO');
+    await testPlan.eliminarRegistros('FUNCIONAL POSITIVO');
+})
+
+// Comando para ejecutar funcional Negativo:
+//! npm run flow:funcionalNegativo
+test('DeleteNegativo', async ({page}) => { //no escribe nada ni no marca error
+    const basePage = new BasePage(page);
+    const testPlan = new TestPlan(page) 
+    await basePage.iniciarSesison('FUNCIONAL NEGATIVO');
+    await testPlan.eliminarRegistros('FUNCIONAL NEGATIVO');
+})
+
+// Comando para ejecutar excepcion:
+//! npm run flow:excepcion
+test('Deleteexcepcion', async ({page}) => { //no escribe nada ni no marca error
+    const basePage = new BasePage(page);
+    const testPlan = new TestPlan(page) 
+    await basePage.iniciarSesison('EXCEPCIÓN');
+    await testPlan.eliminarRegistros('EXCEPCIÓN');
+})
+
+// Comando para ejecutar no Afectacion:
+//! npm run flow:noAfectacion
+test('DeletenoAfectacion', async ({page}) => {
+    const basePage = new BasePage(page);
+    const testPlan = new TestPlan(page) 
+    await basePage.iniciarSesison('NO AFECTACIÓN');
+    await testPlan.eliminarRegistros('NO AFECTACIÓN');
 })

--- a/POM/tests/cargarJira.spec.ts
+++ b/POM/tests/cargarJira.spec.ts
@@ -9,8 +9,8 @@ test.only('funcionalPositivo', async ({page}) => {
     const basePage = new BasePage(page);
     const testPlan = new TestPlan(page) 
     await basePage.iniciarSesison('FUNCIONAL POSITIVO');
-    await testPlan.eliminarRegistros('FUNCIONAL POSITIVO');
-    //await testPlan.registrarMatriz('FUNCIONAL POSITIVO', 16);
+    //await testPlan.eliminarRegistros('FUNCIONAL POSITIVO');
+    await testPlan.registrarMatriz('FUNCIONAL POSITIVO', 16);
 })
 
 // Comando para ejecutar funcional Negativo:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "flow:funcionalPositivo": "npx playwright test cargarJira.spec.ts -g funcionalPositivo",
     "flow:funcionalNegativo": "npx playwright test cargarJira.spec.ts -g funcionalNegativo",
     "flow:excepcion": "npx playwright test cargarJira.spec.ts -g excepcion",
-    "flow:noAfectacion": "npx playwright test cargarJira.spec.ts -g noAfectacion"
+    "flow:noAfectacion": "npx playwright test cargarJira.spec.ts -g noAfectacion",
+    
+    "delete:funcionalPositivo": "npx playwright test cargarJira.spec.ts -g DeletefuncionalPositivo",
+    "delete:funcionalNegativo": "npx playwright test cargarJira.spec.ts -g DeletefuncionalNegativo",
+    "delete:excepcion": "npx playwright test cargarJira.spec.ts -g Deleteexcepcion",
+    "delete:noAfectacion": "npx playwright test cargarJira.spec.ts -g DeletenoAfectacion"
   }
 }


### PR DESCRIPTION



1.- cree los test separados para los metodos que eliminan los datos de los test Cases
2.- Corregí console Log del método que elimina, quete decía la "CANTIDAD TOTAL DE REGISTROS A ELIMINAR" siempre mostraba uno de más
3.- Agregué los comandos al package.json para correr los test de eliminar
4.- Agregué al manual los comandos que permiten eliminar los test Cases
5.- Se resuelve Bug de casos totales, bug en el contador que el dato que se esta registrando actualmente